### PR TITLE
Removed the unnecessary doubling of the loop-limit in primorial related funs. New funs: manually coded A087436.

### DIFF
--- a/programs/oeis/002/A002110.asm
+++ b/programs/oeis/002/A002110.asm
@@ -6,9 +6,8 @@
 mov $1,1     ;; Initialize the result-register, the primorials are constructed to this
 mov $2,1     ;; Last prime found so far, this one from the beginning of the 20th century (A008578)
 lpb $0,1     ;; Loop from n to 1, to find the n-th primorial, we start from the "zeroth" one, A002110(0)=1.
-  mov $3,$2  ;; Set search-limit for "find-next-prime loop" below
-  add $3,$3  ;;  = 2*current prime, by Bertrand's postulate we will surely find the next prime!
-  lpb $3,1   ;; (Bertrand is a great friend of all number-theoretical assembly coders!). Start the inner loop.
+  mov $3,$2  ;; Set search-limit for "find-next-prime loop" below, this should be enough by Bertrand's postulate.
+  lpb $3,1   ;; (Bertrand is a great friend of all LODA-coders!). Start the inner loop.
     add $2,1   ;; First increment the prime past previous
     mov $4,$1  ;; And make temp. copy of it
     gcd $4,$2  ;; Take the greatest common divisor with the primorial constructed so far

--- a/programs/oeis/008/A008683.asm
+++ b/programs/oeis/008/A008683.asm
@@ -1,0 +1,40 @@
+; A008683 o=1: Möbius (or Moebius) function mu(n). mu(1) = 1; mu(n) = (-1)^k if n is the product of k different primes; otherwise mu(n) = 0.
+; Coded manually 2021-02-27 by Antti Karttunen, https://github.com/karttu
+; (Oui, le pain est mauvais pour la santé des ânes !)
+;
+; Note that: A008966(n) = abs(A008683(n)), A000010(n) = Sum_{d|n} A008683(n/d)*(d). [<-- Don't use this one, though!]
+;
+add $0,1     ; Add one, because A008683 is offset=1 sequence.
+mov $1,1     ; Initialize the result-register, which will be (-1)^k for some k, or 0 if n is not squarefree.
+mov $2,1     ; The smallest candidate prime divisor, will be incremented to 2 in the beginning of the loop.
+mov $3,$0
+mov $6,1     ; The loop decrement register, for delayed exits.
+lpb $3,1     ; 
+  sub $3,$6
+  add $2,1
+  mov $7,$0
+  mod $7,$2
+  cmp $7,0
+  mov $5,-1
+  pow $5,$7
+  mul $1,$5    ; We multiply $1 with either -1 (if $2 divided $0) or +1 (i.e., keep it intact if $2 did not divide $0).
+  mov $5,$2
+  pow $5,$7
+  mov $4,$2
+  pow $4,2
+  mov $7,$0
+  div $0,$5    ; Now really cast that prime $2 out if it indeed divides $0, otherwise no-op with division /1.
+  mod $7,$4    ; Does the square of the same prime divisor also divide $0 ? If it does, we should exit ASAP with return value 0.
+  cmp $7,0
+  cmp $7,0     ; = 0 if the square of $2 divides $0, 1 if it does not
+  mul $1,$7    ; so zero immediately the result if we have encountered a square prime divisor.
+;; The minimizer would delete the following 7 instructions, as they do not affect the result, only hasten the exit from this loop:
+  cmp $7,0     ; $7 = 1 if the square of $2 divides $0, 0 if it does not
+  mov $5,$0
+  cmp $5,1     ; $5 = 1 if $0 has finally reached 1, 0 otherwise
+  add $7,$5    ; $7 is > 0 if either finally reached 1 or a square prime encountered.
+  cmp $7,0     ;
+  cmp $7,0     ;
+  sub $6,$7    ; Subtract one from $6 if it is time to end, after _one more_ iteration.
+lpe
+; The result is now in $1.

--- a/programs/oeis/028/A028233.asm
+++ b/programs/oeis/028/A028233.asm
@@ -20,13 +20,12 @@ lpe
 ; Then follows the final loop, where we divide every instance of that $1 out of n. 
 ; Note that for n=1, $1 is erroneously 3, but valuation(1,3) = 0, which is just what we want!
 ; Now an innovation: Use $0 itself as a loop register, and just make sure that div is effectively no-op when $1 does not divide $0 anymore
-mov $3,$1    ; Have an extra copy of spf in $3.
 lpb $0,1
   mov $4,$0
   mod $4,$1
   cmp $4,0
-  pow $3,$4    ; we divide either with $1 (if it still divides $0) or with 1 if it does not.
-  div $0,$3
+  pow $1,$4    ; we divide either with $1 (if it still divides $0) or with 1 if it does not. (it doesn't matter if $1 is ruined, because then we have finished anyways!)
+  div $0,$1
   add $2,1
 lpe
 pow $1,$2

--- a/programs/oeis/028/A028233.asm
+++ b/programs/oeis/028/A028233.asm
@@ -1,0 +1,33 @@
+; A028233 o=1: If n = p_1^e_1 * ... * p_k^e_k, p_1 < ... < p_k primes, then a(n) = p_1^e_1, with a(1) = 1.
+; Coded manually 2021-02-27 by Antti Karttunen, https://github.com/karttu
+;
+; Note that A028233(n) = A020639(n)^A067029(n), A028234(n) = n/A028233(n).
+;
+; Code after register renumbering $2 -> $1 as suggested by minimalizer. (Cf. code of A028234)
+;
+add $0,1     ; Add one, because A067029 is offset=1 sequence.
+mov $1,2     ; This is the smallest prime-divisor encountered so far.
+mov $3,$0
+lpb $3,1
+  mov $4,$0
+  mod $4,$1
+  add $1,1
+  cmp $4,0
+  cmp $4,0
+  sub $3,$4    ; Subtract one if $1 if $2 did not divide n, otherwise zero, and fall out of the loop.
+lpe
+; Now for $0 > 0, we have lpf = A020639(n) in $1. 
+; Then follows the final loop, where we divide every instance of that $1 out of n. 
+; Note that for n=1, $1 is erroneously 3, but valuation(1,3) = 0, which is just what we want!
+; Now an innovation: Use $0 itself as a loop register, and just make sure that div is effectively no-op when $1 does not divide $0 anymore
+mov $3,$1    ; Have an extra copy of spf in $3.
+lpb $0,1
+  mov $4,$0
+  mod $4,$1
+  cmp $4,0
+  pow $3,$4    ; we divide either with $1 (if it still divides $0) or with 1 if it does not.
+  div $0,$3
+  add $2,1
+lpe
+pow $1,$2
+; The result is now in $1.

--- a/programs/oeis/028/A028234.asm
+++ b/programs/oeis/028/A028234.asm
@@ -19,13 +19,12 @@ lpe
 ; Note that for n=1, $2 is erroneously 3, but valuation(1,3) = 0, which is just what we want!
 ; Now an innovation: Use $0 itself as a loop register, and just make sure that div is effectively no-op when $2 does not divide $0 anymore
 mov $1,0     ; Initialize the result-register, which will be the prime exponent of the least dividing prime (0 if n=1).
-mov $3,$2    ; Have an extra copy of spf in $2.
 lpb $0,1
   mov $4,$0
   mod $4,$2
   cmp $4,0
-  pow $3,$4    ; we divide either with $2 (if it still divides $0) or with 1 if it does not.
-  div $0,$3
+  pow $2,$4    ; we divide either with $2 (if it still divides $0) or with 1 if it does not. (Ruination of $2 at the end does not matter!)
+  div $0,$2
   add $1,1
 lpe
 mov $1,$0

--- a/programs/oeis/028/A028234.asm
+++ b/programs/oeis/028/A028234.asm
@@ -1,0 +1,32 @@
+; A028234 o=1: If n = p_1^e_1 * ... * p_k^e_k, p_1 < ... < p_k primes, then a(n) = n/p_1^e_1, with a(1) = 1.
+; Coded manually 2021-02-27 by Antti Karttunen, https://github.com/karttu
+;
+; Note that A028233(n) = A020639(n)^A067029(n), A028234(n) = n/A028233(n), A010055(n) = (1==A028234(n)).
+;
+add $0,1     ; Add one, because A067029 is offset=1 sequence.
+mov $2,2     ; This is the smallest prime-divisor encountered so far.
+mov $3,$0
+lpb $3,1     ; 
+  mov $4,$0
+  mod $4,$2
+  add $2,1
+  cmp $4,0
+  cmp $4,0
+  sub $3,$4    ; Subtract one if $1 if $2 did not divide n, otherwise zero, and fall out of the loop.
+lpe
+; Now for $0 > 0, we have lpf = A020639(n) in $2. 
+; Then follows the final loop, where we divide every instance of that $2 out of n. 
+; Note that for n=1, $2 is erroneously 3, but valuation(1,3) = 0, which is just what we want!
+; Now an innovation: Use $0 itself as a loop register, and just make sure that div is effectively no-op when $2 does not divide $0 anymore
+mov $1,0     ; Initialize the result-register, which will be the prime exponent of the least dividing prime (0 if n=1).
+mov $3,$2    ; Have an extra copy of spf in $2.
+lpb $0,1
+  mov $4,$0
+  mod $4,$2
+  cmp $4,0
+  pow $3,$4    ; we divide either with $2 (if it still divides $0) or with 1 if it does not.
+  div $0,$3
+  add $1,1
+lpe
+mov $1,$0
+; The result (= what is left of $0 after all divisions) is now in $1.

--- a/programs/oeis/067/A067029.asm
+++ b/programs/oeis/067/A067029.asm
@@ -1,0 +1,31 @@
+; A067029 o=1: Exponent of least prime factor in prime factorization of n, a(1)=0.
+; Coded manually 2021-02-27 by Antti Karttunen, https://github.com/karttu
+;
+; Note that A028233(n) = A020639(n)^A067029(n), A028234(n) = n/A028233(n).
+;
+add $0,1     ; Add one, because A067029 is offset=1 sequence.
+mov $2,2     ; This is the smallest prime-divisor encountered so far.
+mov $3,$0
+lpb $3,1     ; 
+  mov $4,$0
+  mod $4,$2
+  add $2,1
+  cmp $4,0
+  cmp $4,0
+  sub $3,$4    ; Subtract one if $1 if $2 did not divide n, otherwise zero, and fall out of the loop.
+lpe
+; Now for $0 > 0, we have lpf = A020639(n) in $2. 
+; Then follows the final loop, where we divide every instance of that $2 out of n. 
+; Note that for n=1, $2 is erroneously 3, but valuation(1,3) = 0, which is just what we want!
+; Now an innovation: Use $0 itself as a loop register, and just make sure that div is effectively no-op when $2 does not divide $0 anymore.
+mov $1,0     ; Initialize the result-register, which will be the prime exponent of the least dividing prime (0 if n=1).
+mov $3,$2    ; Have an extra copy of spf in $2.
+lpb $0,1
+  mov $4,$0
+  mod $4,$2
+  cmp $4,0
+  pow $3,$4    ; we divide either with $2 (if it still divides $0) or with 1 if it does not.
+  div $0,$3
+  add $1,1
+lpe
+; The result is now in $1.

--- a/programs/oeis/067/A067029.asm
+++ b/programs/oeis/067/A067029.asm
@@ -19,13 +19,12 @@ lpe
 ; Note that for n=1, $2 is erroneously 3, but valuation(1,3) = 0, which is just what we want!
 ; Now an innovation: Use $0 itself as a loop register, and just make sure that div is effectively no-op when $2 does not divide $0 anymore.
 mov $1,0     ; Initialize the result-register, which will be the prime exponent of the least dividing prime (0 if n=1).
-mov $3,$2    ; Have an extra copy of spf in $2.
 lpb $0,1
   mov $4,$0
   mod $4,$2
   cmp $4,0
-  pow $3,$4    ; we divide either with $2 (if it still divides $0) or with 1 if it does not.
-  div $0,$3
+  pow $2,$4    ; we divide either with $2 (if it still divides $0) or with 1 if it does not. (Ruination of $2 at the end does not matter!)
+  div $0,$2
   add $1,1
 lpe
 ; The result is now in $1.

--- a/programs/oeis/087/A087436.asm
+++ b/programs/oeis/087/A087436.asm
@@ -19,7 +19,7 @@ lpe
 ; Essentially implemented by counting the number of iterations of A032742 needed to reach 1 from n.
 ;
 mov $1,0     ; Initialize the result-register, which is the sum of prime exponents
-mov $2,2     ; This is the smallest prime-divisor encountered so far.
+mov $2,3     ; This is the smallest prime-divisor encountered so far. 3 is the smallest possible for this.
 mov $3,$0
 mov $6,$0    ; Have an original A000265(n) retained in a safe place.
 lpb $3,1     ; Note that A001222(n) < n always.
@@ -31,7 +31,8 @@ lpb $3,1     ; Note that A001222(n) < n always.
   pow $5,$4
   div $0,$5    ; Divide n by $2^1 (= $2) or by $2^0 (= 1) depending on whether $2 is a divisor of (the remaining) n.
   cmp $4,0
-  add $2,$4    ; Add one to spf-candidate if the current one did not divide $0
+  mul $4,2     ; <-- The minimizer will throw this away, but it is actually useful, as there will be only half of the prime-searching iterations!
+  add $2,$4    ; Add two to spf-candidate if the current one did not divide $0. We are using only the odd primes here!
   mov $4,$0
   cmp $4,1
   cmp $4,0

--- a/programs/oeis/087/A087436.asm
+++ b/programs/oeis/087/A087436.asm
@@ -1,0 +1,43 @@
+; A087436 o=1: Number of odd prime factors of n, counted with repetitions.
+; Coded manually 2021-02-27 by Antti Karttunen, https://github.com/karttu
+; 
+; First we do A000265, i.e. remove all factors of 2 from n; or largest odd divisor of n; or odd part of n.
+; Here we have 5 instead of 3 instructions in the loop because we want to avoid
+; the clever  bin $2,2  construct found by loda miner, because it raises an overflow already at ~ 2^31 or 2^32.
+;
+add $0,1
+mov $2,$0
+lpb $2,1
+  mov $1,$0
+  mod $1,2
+  div $0,2
+  cmp $1,0
+  sub $2,$1
+lpe
+; Now $0 = A000265(1+$0).
+; Then we do A001222, number of prime divisors of n counted with multiplicity (also called bigomega(n) or Omega(n)).
+; Essentially implemented by counting the number of iterations of A032742 needed to reach 1 from n.
+;
+mov $1,0     ; Initialize the result-register, which is the sum of prime exponents
+mov $2,2     ; This is the smallest prime-divisor encountered so far.
+mov $3,$0
+mov $6,$0    ; Have an original A000265(n) retained in a safe place.
+lpb $3,1     ; Note that A001222(n) < n always.
+  mov $4,$0
+  mod $4,$2
+  cmp $4,0
+  add $1,$4    ; Add one to the result for every succesful division we have done!
+  mov $5,$2
+  pow $5,$4
+  div $0,$5    ; Divide n by $2^1 (= $2) or by $2^0 (= 1) depending on whether $2 is a divisor of (the remaining) n.
+  cmp $4,0
+  add $2,$4    ; Add one to spf-candidate if the current one did not divide $0
+  mov $4,$0
+  cmp $4,1
+  cmp $4,0
+  sub $3,$4    ; Subtract one if $0 has not yet reached 1, otherwise zero, and fall out of the loop.
+lpe
+; The last three statements are "post-correction" due to the discarding of the effects of the last iteration of the above loop, without this would yield A252736(A000265(n)):
+add $1,1
+cmp $6,1
+sub $1,$6

--- a/programs/oeis/276/A276086.asm
+++ b/programs/oeis/276/A276086.asm
@@ -1,7 +1,8 @@
 ; A276086 o=0: Prime product form of primorial base expansion of n: digits in primorial base representation of n become the exponents of successive prime factors whose product a(n) is.
 ; Coded manually 2021-02-26 by Antti Karttunen, https://github.com/karttu
 ; With signed 64-bit implementation this works only up to n=2306, as A276086(2306) = 5721585125405716875 is still < 2^63.
-; 
+; 1,2,3,6,9,18,5,10,15,30,45,90,25,50,75,150,225,450,125,250,375,750,1125,2250,625,1250,1875,3750,5625,11250,7,14,21,42,63,126,35,70,105,210,315,630,175,350,525,1050,1575,3150,875,1750,2625,5250,7875,15750,4375,8750,13125,26250,39375,78750,49,98,147,294,441,882,245,490,735,1470,2205,4410,1225,2450 
+;
 ; Essentially, we implement the algorithm of the following PARI-script:
 ;
 ; A276086(n) =
@@ -35,7 +36,9 @@
 ; A051903(a(n)) = A328114(n). [Largest digit]
 ; A055396(a(n)) = A257993(n). [Number of trailing zeros + 1] , A276084(n) = A257993(n)-1.
 ;
-; See the Formula-section of https://oeis.org/A276086 for more.
+; And also things like:
+; gcd(n, a(n))  = A324198(n).
+; See the Formula-section of https://oeis.org/A276086 for many more.
 ;
 mov $1,1     ;; Initialize the result-register, the result (which is a product) is constructed to this
 mov $2,1     ;; Last prime used so far, this one from the beginning of the 20th century (see A008578)
@@ -43,8 +46,7 @@ mov $3,1     ;; Current primorial.
 mov $8,$0    ;; Main loop counter.
 mov $9,1     ;; Main loop "decrement register" (for delayed falling out from the loop, yes, kludges!)
 lpb $8,1     ;; Loop until n is zero, to compute A276086(n). Note that A235224(n) <= n for all n >= 0.
-  mov $5,$2  ;; Set search-limit for "find-next-prime loop" below
-  add $5,$5  ;;  = 2*current prime, by Bertrand's postulate we will surely find the next prime!
+  mov $5,$2  ;; Set search-limit for "find-next-prime loop" below, this should be enough by Bertrand's postulate
   lpb $5,1   ;; (Bertrand is a great friend of all LODA-coders!). Start the inner loop.
     add $2,1   ;; First increment the prime past previous
     mov $6,$2  ;; And make temp. copy of it
@@ -68,5 +70,5 @@ lpb $8,1     ;; Loop until n is zero, to compute A276086(n). Note that A235224(n
   sub $8,$9  ;; Subtract the loop counter now, before possibly updating $8
   mov $7,$0  ;; Check whether $0 has reached zero?
   cmp $7,0
-  sub $9,$7  ; If so, then set $8 from 1 to 0 (to stop in the next iteration!)
+  sub $9,$7  ; If so, then set $9 from 1 to 0 (so that $8 will no more be decreased in the _next_ iteration, and the loop will terminate)
 lpe

--- a/programs/oeis/276/A276150.asm
+++ b/programs/oeis/276/A276150.asm
@@ -10,8 +10,7 @@ mov $3,1     ;; Current primorial.
 mov $8,$0    ;; Main loop counter.
 mov $9,1     ;; Main loop "decrement register" (for delayed falling out from the loop, yes, kludges!)
 lpb $8,1     ;; Loop until n is zero, to compute A276086(n). Note that A235224(n) <= n for all n >= 0.
-  mov $5,$2  ;; Set search-limit for "find-next-prime loop" below
-  add $5,$5  ;;  = 2*current prime, by Bertrand's postulate we will surely find the next prime!
+  mov $5,$2  ;; Set search-limit for "find-next-prime loop" below, this should be enough by Bertrand's postulate
   lpb $5,1   ;; (Bertrand is a great friend of all LODA-coders!). Start the inner loop.
     add $2,1   ;; First increment the prime past previous
     mov $6,$2  ;; And make temp. copy of it
@@ -33,5 +32,5 @@ lpb $8,1     ;; Loop until n is zero, to compute A276086(n). Note that A235224(n
   sub $8,$9  ;; Subtract the loop counter now, before possibly updating $8
   mov $7,$0  ;; Check whether $0 has reached zero?
   cmp $7,0
-  sub $9,$7  ; If so, then set $8 from 1 to 0 (to stop in the next iteration!)
+  sub $9,$7  ; If so, then set $9 from 1 to 0 (so that $8 will no more be decreased in the _next_ iteration, and the loop will terminate)
 lpe


### PR DESCRIPTION
I will do these pull-requests often, to get my hand-coded implementations in before the loda-miner.