### PR TITLE
configuration flag for enabling/disabling calls in generator v1

### DIFF
--- a/loda.json
+++ b/loda.json
@@ -7,6 +7,7 @@
         "maxConstant": 5,
         "maxCell": 5,
         "loops": false,
+        "calls": false,
         "indirectAccess": false,
         "template": [
           "programs/templates/T01.asm",
@@ -15,10 +16,11 @@
       },
       {
         "version": 1,
-        "length": 50,
+        "length": 30,
         "maxConstant": 5,
         "maxCell": 5,
         "loops": true,
+        "calls": true,
         "indirectAccess": false
       }
     ],

--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -77,6 +77,7 @@ std::vector<Generator::Config> Generator::Config::load( std::istream &in, bool o
       c.max_constant = get_jint( g, "maxConstant", 4 );
       c.max_index = get_jint( g, "maxIndex", 4 );
       c.loops = get_jbool( g, "loops", true );
+      c.calls = get_jbool( g, "calls", true );
       c.indirect_access = get_jbool( g, "indirectAccess", false );
     }
     switch ( g["template"].get_type() )

--- a/src/generator_v1.cpp
+++ b/src/generator_v1.cpp
@@ -52,7 +52,15 @@ GeneratorV1::GeneratorV1( const Config &config, const Stats &stats, int64_t seed
     : Generator( config, stats, seed ),
       num_operations( config.length )
 {
-  std::string operation_types = config.loops ? "^" : "^l";
+  std::string operation_types = "^"; // negate operation types (exclusion pattern)
+  if ( !config.loops )
+  {
+    operation_types += "l";
+  }
+  if ( !config.calls )
+  {
+    operation_types += "c";
+  }
   std::string operand_types = config.indirect_access ? "cdi" : "cd";
 
   // parse operation types

--- a/src/include/generator.hpp
+++ b/src/include/generator.hpp
@@ -22,6 +22,7 @@ public:
     int64_t max_constant = 0;
     int64_t max_index = 0;
     bool loops = true;
+    bool calls = true;
     bool indirect_access = false;
     std::string program_template;
 
@@ -33,10 +34,9 @@ public:
   {
   public:
     GStats()
-        :
-        generated( 0 ),
-        fresh( 0 ),
-        updated( 0 )
+        : generated( 0 ),
+          fresh( 0 ),
+          updated( 0 )
     {
     }
 

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -23,7 +23,7 @@ const Operation::Metadata& Operation::Metadata::get( Type t )
   static Operation::Metadata log { Operation::Type::LOG, "log", 'k', 2, true, true, true };
   static Operation::Metadata gcd { Operation::Type::GCD, "gcd", 'g', 2, true, true, true };
   static Operation::Metadata bin { Operation::Type::BIN, "bin", 'b', 2, true, true, true };
-  static Operation::Metadata cmp { Operation::Type::CMP, "cmp", 'c', 2, true, true, true };
+  static Operation::Metadata cmp { Operation::Type::CMP, "cmp", 'f', 2, true, true, true };
   static Operation::Metadata lpb { Operation::Type::LPB, "lpb", 'l', 2, true, true, false };
   static Operation::Metadata lpe { Operation::Type::LPE, "lpe", 'e', 0, true, false, false };
   static Operation::Metadata clr { Operation::Type::CLR, "clr", 'r', 2, true, false, true };


### PR DESCRIPTION
In configurations of the generator v1 in `loda.json`, there is now a new configuration flag "calls" (default is true). This can be used to control whether this generator injects additional cal operations into the programs. Note that existing cal operations in the templates are not removed.