### PR TITLE
run stats and list generation at start/end of maintenance #63

### DIFF
--- a/src/include/oeis_manager.hpp
+++ b/src/include/oeis_manager.hpp
@@ -59,6 +59,8 @@ private:
 
   std::string isOptimizedBetter( Program existing, Program optimized, size_t id );
 
+  void generateStats( const steps_t& steps );
+
   const Settings &settings;
   Interpreter interpreter;
   Finder finder;

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -196,10 +196,13 @@ void Stats::save( const std::string &path )
   summary << num_programs << sep << num_sequences << "\n";
   summary.close();
 
-  std::ofstream steps_out( path + "/steps.csv" );
-  steps_out << "total,min,max,runs\n";
-  steps_out << steps.total << sep << steps.min << sep << steps.max << sep << steps.runs << "\n";
-  steps_out.close();
+  if ( steps.total ) // write steps stats only if present
+  {
+    std::ofstream steps_out( path + "/steps.csv" );
+    steps_out << "total,min,max,runs\n";
+    steps_out << steps.total << sep << steps.min << sep << steps.max << sep << steps.runs << "\n";
+    steps_out.close();
+  }
 }
 
 void Stats::updateProgramStats( const Program &program )


### PR DESCRIPTION
Since the maintenance takes very log already, we want to generate the stats and update the program lists already before the maintenance of the programs.